### PR TITLE
Custom canApply for Lycanites Equipment + Restored super.canApplyAtEnchantingTable method call

### DIFF
--- a/src/main/java/com/shultrea/rin/config/CanApplyConfig.java
+++ b/src/main/java/com/shultrea/rin/config/CanApplyConfig.java
@@ -9,6 +9,7 @@ public class CanApplyConfig {
 	public String[] customTypes = {
 			"BATTLEAXE;(mujmajnkraftsbettersurvival\\:item.*battleaxe)|(spartan(defiled|fire|weaponry)\\:battleaxe.*)",
 			"BS_WEAPON;mujmajnkraftsbettersurvival\\:item.*(dagger|nunchaku|hammer|battleaxe)",
+			"LYCANITES_EQUIPMENT;lycanitesmobs:equipment",
 			"NOT_GOLD;.*gold.*;NOT",
 			"SW_CROSSBOW;spartan(defiled|fire|weaponry)\\:crossbow.*",
 			"WOLFARMOR;wolfarmor\\:\\w+\\_wolf\\_armor",
@@ -17,25 +18,25 @@ public class CanApplyConfig {
 
 	@Config.Name("Adept")
 	@Config.RequiresMcRestart
-	public String[] adept = {"SWORD", "AXE", "BOW", "BATTLEAXE", "BS_WEAPON", "SW_CROSSBOW"};
+	public String[] adept = {"SWORD", "AXE", "BOW", "BATTLEAXE", "BS_WEAPON", "LYCANITES_EQUIPMENT", "SW_CROSSBOW"};
 	@Config.Name("Ancient Sealed Curses")
 	@Config.RequiresMcRestart
-	public String[] ancientSealedCurses = {"SWORD", "BS_WEAPON"};
+	public String[] ancientSealedCurses = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Ancient Sword Mastery")
 	@Config.RequiresMcRestart
-	public String[] ancientSwordMastery = {"SWORD", "BS_WEAPON"};
+	public String[] ancientSwordMastery = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Arc Slash")
 	@Config.RequiresMcRestart
 	public String[] arcSlash = {"SWORD", "BS_WEAPON"};
 	@Config.Name("Ash Destroyer")
 	@Config.RequiresMcRestart
-	public String[] ashDestroyer = {"SWORD", "BS_WEAPON", "NOT_FLAMED_WEAPON"};
+	public String[] ashDestroyer = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT", "NOT_FLAMED_WEAPON"};
 	@Config.Name("Atomic Deconstructor")
 	@Config.RequiresMcRestart
-	public String[] atomicDeconstructor = {"SWORD", "BS_WEAPON"};
+	public String[] atomicDeconstructor = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Blessed Edge")
 	@Config.RequiresMcRestart
-	public String[] blessedEdge = {"SWORD", "BS_WEAPON"};
+	public String[] blessedEdge = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Brutality")
 	@Config.RequiresMcRestart
 	public String[] brutality = {"AXE", "BATTLEAXE"};
@@ -47,64 +48,64 @@ public class CanApplyConfig {
 	public String[] burningThorns = {"ARMOR_CHEST"};
 	@Config.Name("Butchering")
 	@Config.RequiresMcRestart
-	public String[] butchering = {"SWORD", "BS_WEAPON"};
+	public String[] butchering = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Clearskies' Favor")
 	@Config.RequiresMcRestart
-	public String[] clearskiesFavor = {"SWORD", "BS_WEAPON"};
+	public String[] clearskiesFavor = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Combat Medic")
 	@Config.RequiresMcRestart
 	public String[] combatMedic = {"ARMOR_HEAD"};
 	@Config.Name("Counter Attack")
 	@Config.RequiresMcRestart
-	public String[] counterAttack = {"SWORD", "BS_WEAPON"};
+	public String[] counterAttack = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Critical Strike")
 	@Config.RequiresMcRestart
-	public String[] criticalStrike = {"SWORD","AXE", "BATTLEAXE", "BS_WEAPON"};
+	public String[] criticalStrike = {"SWORD","AXE", "BATTLEAXE", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Culling")
 	@Config.RequiresMcRestart
 	public String[] culling = {"AXE", "BATTLEAXE"};
 	@Config.Name("Dark Shadows")
 	@Config.RequiresMcRestart
-	public String[] darkShadows = {"SWORD", "BS_WEAPON"};
+	public String[] darkShadows = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Defusing Edge")
 	@Config.RequiresMcRestart
-	public String[] defusingEdge = {"SWORD", "BS_WEAPON"};
+	public String[] defusingEdge = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Desolator")
 	@Config.RequiresMcRestart
 	public String[] desolator = {"AXE", "BATTLEAXE"};
 	@Config.Name("Difficulty's Endowment")
 	@Config.RequiresMcRestart
-	public String[] difficultysEndowment = {"SWORD", "BS_WEAPON"};
+	public String[] difficultysEndowment = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Disarmament")
 	@Config.RequiresMcRestart
 	public String[] disarmament = {"AXE", "BATTLEAXE"};
 	@Config.Name("Disorientating Blade")
 	@Config.RequiresMcRestart
-	public String[] disorientatingBlade = {"SWORD", "BS_WEAPON"};
+	public String[] disorientatingBlade = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Empowered Defence")
 	@Config.RequiresMcRestart
 	public String[] empoweredDefence = {"SHIELD"};
 	@Config.Name("Envenomed")
 	@Config.RequiresMcRestart
-	public String[] envenomed = {"SWORD", "BS_WEAPON"};
+	public String[] envenomed = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Evasion")
 	@Config.RequiresMcRestart
 	public String[] evasion = {"ARMOR_LEGS"};
 	@Config.Name("Fiery Edge")
 	@Config.RequiresMcRestart
-	public String[] fieryEdge = {"SWORD", "BS_WEAPON"};
+	public String[] fieryEdge = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Flinging")
 	@Config.RequiresMcRestart
-	public String[] flinging = {"SWORD", "BS_WEAPON"};
+	public String[] flinging = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Cryogenic")
 	@Config.RequiresMcRestart
-	public String[] cryogenic = {"SWORD", "BS_WEAPON"};
+	public String[] cryogenic = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Hors De Combat")
 	@Config.RequiresMcRestart
-	public String[] horsDeCombat = {"SWORD", "BS_WEAPON"};
+	public String[] horsDeCombat = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Inhumane")
 	@Config.RequiresMcRestart
-	public String[] inhumane = {"SWORD", "BS_WEAPON"};
+	public String[] inhumane = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Inner Berserk")
 	@Config.RequiresMcRestart
 	public String[] innerBerserk = {"ARMOR_CHEST"};
@@ -113,19 +114,19 @@ public class CanApplyConfig {
 	public String[] jaggedRake = {"HOE"};
 	@Config.Name("Levitator")
 	@Config.RequiresMcRestart
-	public String[] levitator = {"SWORD", "BS_WEAPON"};
+	public String[] levitator = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Lifesteal")
 	@Config.RequiresMcRestart
-	public String[] lifesteal = {"SWORD", "BS_WEAPON"};
+	public String[] lifesteal = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Light Weight")
 	@Config.RequiresMcRestart
 	public String[] lightWeight = {"ARMOR_FEET"};
 	@Config.Name("Luck Magnification")
 	@Config.RequiresMcRestart
-	public String[] luckMagnification = {"SWORD","AXE", "BATTLEAXE", "BS_WEAPON"};
+	public String[] luckMagnification = {"SWORD","AXE", "BATTLEAXE", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Lunas Blessing")
 	@Config.RequiresMcRestart
-	public String[] lunasBlessing = {"SWORD", "BS_WEAPON"};
+	public String[] lunasBlessing = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Magic Protection")
 	@Config.RequiresMcRestart
 	public String[] magicProtection = {"ARMOR"};
@@ -140,13 +141,13 @@ public class CanApplyConfig {
 	public String[] moisturized = {"HOE"};
 	@Config.Name("Mortalitas")
 	@Config.RequiresMcRestart
-	public String[] mortalitas = {"SWORD","AXE", "BATTLEAXE", "BS_WEAPON"};
+	public String[] mortalitas = {"SWORD","AXE", "BATTLEAXE", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Natural Blocking")
 	@Config.RequiresMcRestart
 	public String[] naturalBlocking = {"SHIELD"};
 	@Config.Name("Parry")
 	@Config.RequiresMcRestart
-	public String[] parry = {"SWORD", "BS_WEAPON"};
+	public String[] parry = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Penetrating Edge")
 	@Config.RequiresMcRestart
 	public String[] penetratingEdge = {"AXE", "BATTLEAXE"};
@@ -158,7 +159,7 @@ public class CanApplyConfig {
 	public String[] dragging = {"BOW","SW_CROSSBOW"};
 	@Config.Name("Purging Blade")
 	@Config.RequiresMcRestart
-	public String[] purgingBlade = {"SWORD", "BS_WEAPON"};
+	public String[] purgingBlade = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Purification")
 	@Config.RequiresMcRestart
 	public String[] purification = {"AXE", "BATTLEAXE"};
@@ -167,22 +168,22 @@ public class CanApplyConfig {
 	public String[] pushing = {"BOW"};
 	@Config.Name("Rain's Bestowment")
 	@Config.RequiresMcRestart
-	public String[] rainsBestowment = {"SWORD", "BS_WEAPON"};
+	public String[] rainsBestowment = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Reviled Blade")
 	@Config.RequiresMcRestart
-	public String[] reviledBlade = {"SWORD", "BS_WEAPON"};
+	public String[] reviledBlade = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Reinforced Sharpness")
 	@Config.RequiresMcRestart
-	public String[] reinforcedsharpness = {"TOOL"};
+	public String[] reinforcedsharpness = {"TOOL", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Smelter")
 	@Config.RequiresMcRestart
 	public String[] smelter = {"TOOL"};
 	@Config.Name("Sol's Blessing")
 	@Config.RequiresMcRestart
-	public String[] solsBlessing = {"SWORD", "BS_WEAPON"};
+	public String[] solsBlessing = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Spell Breaker")
 	@Config.RequiresMcRestart
-	public String[] spellBreaker = {"SWORD","AXE", "BATTLEAXE", "BS_WEAPON"};
+	public String[] spellBreaker = {"SWORD","AXE", "BATTLEAXE", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Splitshot")
 	@Config.RequiresMcRestart
 	public String[] splitShot = {"BOW"};
@@ -194,48 +195,48 @@ public class CanApplyConfig {
 	public String[] strengthenedVitality = {"ARMOR_CHEST"};
 	@Config.Name("Swifter Slashes")
 	@Config.RequiresMcRestart
-	public String[] swifterSlashes = {"SWORD", "BS_WEAPON"};
+	public String[] swifterSlashes = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Thunderstorm's Bestowment")
 	@Config.RequiresMcRestart
-	public String[] thunderstormsBestowment = {"SWORD", "BS_WEAPON"};
+	public String[] thunderstormsBestowment = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("True Strike")
 	@Config.RequiresMcRestart
-	public String[] trueStrike = {"SWORD", "BS_WEAPON"};
+	public String[] trueStrike = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Swift Swimming")
 	@Config.RequiresMcRestart
 	public String[] swiftSwimming = {"ARMOR_FEET"};
 	@Config.Name("Unreasonable")
 	@Config.RequiresMcRestart
-	public String[] unreasonable = {"SWORD", "BS_WEAPON"};
+	public String[] unreasonable = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Unsheathing")
 	@Config.RequiresMcRestart
-	public String[] unsheathing = {"SWORD", "BS_WEAPON"};
+	public String[] unsheathing = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Upgraded Potentials")
 	@Config.RequiresMcRestart
 	public String[] upgradedPotentials = {"NONE"};
 	@Config.Name("Viper")
 	@Config.RequiresMcRestart
-	public String[] viper = {"SWORD", "BS_WEAPON"};
+	public String[] viper = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Water Aspect")
 	@Config.RequiresMcRestart
-	public String[] waterAspect = {"SWORD", "BS_WEAPON"};
+	public String[] waterAspect = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Plowing")
 	@Config.RequiresMcRestart
 	public String[] plowing = {"HOE"};
 	@Config.Name("Winter's Grace")
 	@Config.RequiresMcRestart
-	public String[] wintersGrace = {"SWORD", "BS_WEAPON"};
+	public String[] wintersGrace = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 
 	//Curses
 	@Config.Name("Bluntness")
 	@Config.RequiresMcRestart
-	public String[] bluntness = {"SWORD","AXE", "BATTLEAXE", "BS_WEAPON"};
+	public String[] bluntness = {"SWORD","AXE", "BATTLEAXE", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Breached Plating")
 	@Config.RequiresMcRestart
 	public String[] breachedPlating = {"ARMOR"};
 	@Config.Name("Cursed Edge")
 	@Config.RequiresMcRestart
-	public String[] cursedEdge = {"SWORD", "BS_WEAPON"};
+	public String[] cursedEdge = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Curse of Decay")
 	@Config.RequiresMcRestart
 	public String[] curseOfDecay = {"ALL_ITEMS"};
@@ -244,7 +245,7 @@ public class CanApplyConfig {
 	public String[] curseOfHolding = {"ALL_ITEMS"};
 	@Config.Name("Curse of Inaccuracy")
 	@Config.RequiresMcRestart
-	public String[] curseOfInaccuracy = {"SWORD","AXE","BOW", "BATTLEAXE", "BS_WEAPON"};
+	public String[] curseOfInaccuracy = {"SWORD","AXE","BOW", "BATTLEAXE", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Curse of Possession")
 	@Config.RequiresMcRestart
 	public String[] curseOfPossession = {"ALL_TYPES"};
@@ -256,7 +257,7 @@ public class CanApplyConfig {
 	public String[] heavyWeight = {"ALL_ITEMS"};
 	@Config.Name("Inefficient")
 	@Config.RequiresMcRestart
-	public String[] inefficient = {"TOOL"};
+	public String[] inefficient = {"TOOL", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Instability")
 	@Config.RequiresMcRestart
 	public String[] instability = {"SWORD","TOOL", "BS_WEAPON"};
@@ -271,13 +272,13 @@ public class CanApplyConfig {
 	public String[] rusted = {"BREAKABLE","NOT_GOLD"};
 	@Config.Name("Unpredictable")
 	@Config.RequiresMcRestart
-	public String[] unpredictable = {"SWORD", "BS_WEAPON"};
+	public String[] unpredictable = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Ascetic")
 	@Config.RequiresMcRestart
-	public String[] ascetic = {"SWORD", "BS_WEAPON", "AXE", "FISHING_ROD"};
+	public String[] ascetic = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT", "AXE", "FISHING_ROD"};
 	@Config.Name("Extinguish")
 	@Config.RequiresMcRestart
-	public String[] extinguish = {"SWORD", "BS_WEAPON", "AXE","BOW", "SW_CROSSBOW"};
+	public String[] extinguish = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT", "AXE","BOW", "SW_CROSSBOW"};
 
 	//Rune
 	@Config.Name("Rune: Arrow Piercing")
@@ -285,10 +286,10 @@ public class CanApplyConfig {
 	public String[] runeArrowPiercing = {"BOW", "SW_CROSSBOW"};
 	@Config.Name("Rune: Magical Blessing")
 	@Config.RequiresMcRestart
-	public String[] runeMagicalBlessing = {"SWORD", "BS_WEAPON"};
+	public String[] runeMagicalBlessing = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Rune: Piercing Capabilities")
 	@Config.RequiresMcRestart
-	public String[] runePiercingCapabilities = {"SWORD", "BS_WEAPON"};
+	public String[] runePiercingCapabilities = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Rune: Resurrection")
 	@Config.RequiresMcRestart
 	public String[] runeResurrection = {"SHIELD"};
@@ -299,58 +300,58 @@ public class CanApplyConfig {
 	//Subject
 	@Config.Name("Subject Biology")
 	@Config.RequiresMcRestart
-	public String[] subjectBiology = {"SWORD", "BS_WEAPON"};
+	public String[] subjectBiology = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Subject Chemistry")
 	@Config.RequiresMcRestart
-	public String[] subjectChemistry = {"SWORD", "BS_WEAPON"};
+	public String[] subjectChemistry = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Subject English")
 	@Config.RequiresMcRestart
-	public String[] subjectEnglish = {"SWORD", "BS_WEAPON"};
+	public String[] subjectEnglish = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Subject History")
 	@Config.RequiresMcRestart
-	public String[] subjectHistory = {"SWORD", "BS_WEAPON"};
+	public String[] subjectHistory = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Subject Mathematics")
 	@Config.RequiresMcRestart
-	public String[] subjectMathematics = {"SWORD", "BS_WEAPON"};
+	public String[] subjectMathematics = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Subject P.E.")
 	@Config.RequiresMcRestart
-	public String[] subjectPE = {"SWORD", "BS_WEAPON"};
+	public String[] subjectPE = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Subject Physics")
 	@Config.RequiresMcRestart
-	public String[] subjectPhysics = {"SWORD", "BS_WEAPON"};
+	public String[] subjectPhysics = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	//Lesser
 	@Config.Name("Lesser Bane of Arthropods")
 	@Config.RequiresMcRestart
-	public String[] lesserBaneOfArthropods = {"SWORD", "BS_WEAPON"};
+	public String[] lesserBaneOfArthropods = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Lesser Fire Aspect")
 	@Config.RequiresMcRestart
-	public String[] lesserFireAspect = {"SWORD", "BS_WEAPON"};
+	public String[] lesserFireAspect = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Lesser Flame")
 	@Config.RequiresMcRestart
 	public String[] lesserFlame = {"BOW", "SW_CROSSBOW"};
 	@Config.Name("Lesser Sharpness")
 	@Config.RequiresMcRestart
-	public String[] lesserSharpness = {"SWORD", "BS_WEAPON"};
+	public String[] lesserSharpness = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Lesser Smite")
 	@Config.RequiresMcRestart
-	public String[] lesserSmite = {"SWORD", "BS_WEAPON"};
+	public String[] lesserSmite = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	
 	//Advanced
 	@Config.Name("Advanced Bane of Arthropods")
 	@Config.RequiresMcRestart
-	public String[] advancedBaneOfArthropods = {"SWORD", "BS_WEAPON"};
+	public String[] advancedBaneOfArthropods = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Advanced Blast Protection")
 	@Config.RequiresMcRestart
 	public String[] advancedBlastProtection = {"ARMOR"};
 	@Config.Name("Advanced Efficiency")
 	@Config.RequiresMcRestart
-	public String[] advancedEfficiency = {"TOOL"};
+	public String[] advancedEfficiency = {"TOOL", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Advanced Feather Falling")
 	@Config.RequiresMcRestart
 	public String[] advancedFeatherFalling = {"ARMOR_FEET"};
 	@Config.Name("Advanced Fire Aspect")
 	@Config.RequiresMcRestart
-	public String[] advancedFireAspect = {"SWORD", "BS_WEAPON"};
+	public String[] advancedFireAspect = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Advanced Fire Protection")
 	@Config.RequiresMcRestart
 	public String[] advancedFireProtection = {"ARMOR"};
@@ -359,10 +360,10 @@ public class CanApplyConfig {
 	public String[] advancedFlame = {"BOW", "SW_CROSSBOW"};
 	@Config.Name("Advanced Knockback")
 	@Config.RequiresMcRestart
-	public String[] advancedKnockback = {"SWORD", "BS_WEAPON"};
+	public String[] advancedKnockback = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Advanced Looting")
 	@Config.RequiresMcRestart
-	public String[] advancedLooting = {"SWORD", "BS_WEAPON"};
+	public String[] advancedLooting = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Advanced Luck of the Sea")
 	@Config.RequiresMcRestart
 	public String[] advancedLuckOfTheSea = {"FISHING_ROD"};
@@ -386,27 +387,27 @@ public class CanApplyConfig {
 	public String[] advancedPunch = {"BOW", "SW_CROSSBOW"};
 	@Config.Name("Advanced Sharpness")
 	@Config.RequiresMcRestart
-	public String[] advancedSharpness = {"SWORD", "BS_WEAPON"};
+	public String[] advancedSharpness = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Advanced Smite")
 	@Config.RequiresMcRestart
-	public String[] advancedSmite = {"SWORD", "BS_WEAPON"};
+	public String[] advancedSmite = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Advanced Thorns")
 	@Config.RequiresMcRestart
 	public String[] advancedThorns = {"ARMOR_CHEST"};
 	//Supreme
 	@Config.Name("Supreme Bane of Arthropods")
 	@Config.RequiresMcRestart
-	public String[] supremeBaneOfArthropods = {"SWORD", "BS_WEAPON"};
+	public String[] supremeBaneOfArthropods = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Supreme Fire Aspect")
 	@Config.RequiresMcRestart
-	public String[] supremeFireAspect = {"SWORD", "BS_WEAPON"};
+	public String[] supremeFireAspect = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Supreme Flame")
 	@Config.RequiresMcRestart
 	public String[] supremeFlame = {"BOW", "SW_CROSSBOW"};
 	@Config.Name("Supreme Sharpness")
 	@Config.RequiresMcRestart
-	public String[] supremeSharpness = {"SWORD", "BS_WEAPON"};
+	public String[] supremeSharpness = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 	@Config.Name("Supreme Smite")
 	@Config.RequiresMcRestart
-	public String[] supremeSmite = {"SWORD", "BS_WEAPON"};
+	public String[] supremeSmite = {"SWORD", "BS_WEAPON", "LYCANITES_EQUIPMENT"};
 }

--- a/src/main/java/com/shultrea/rin/enchantments/base/EnchantmentBase.java
+++ b/src/main/java/com/shultrea/rin/enchantments/base/EnchantmentBase.java
@@ -22,7 +22,7 @@ public abstract class EnchantmentBase extends Enchantment {
 	public ArrayList<Enchantment> incompatibleEnchantments = new ArrayList<>();
 
 	public EnchantmentBase(String name, Rarity rarity, EntityEquipmentSlot... slots) {
-		super(rarity, Types.NONE, slots);
+		super(rarity, Types.ALL, slots);
 		this.name = name;
 		this.setRegistryName(SoManyEnchantments.MODID, name);
 	}
@@ -85,7 +85,7 @@ public abstract class EnchantmentBase extends Enchantment {
 	 */
 	@Override
 	public boolean canApplyAtEnchantingTable(ItemStack stack) {
-		return this.isEnabled();
+		return this.isEnabled() && super.canApplyAtEnchantingTable(stack);
 	}
 	
 	/**


### PR DESCRIPTION
Set of changes intending to have Lycanites Equipment only be enchantable if all parts are at level 3. LycanitesTweaks mod handles Lycanites Equipment's Item call of canApplyAtEnchantingTable, doing a condition check and whitelisting vanilla enchantments.

Set EnchantmentBase Type to ALL and made canApplyAtEnchantingTable call super. Restores items checking if they can be enchanted.  Every SME enchantment overrides and uses the config filter so this does not cause issues with SME enchants being able to be applied to everything.

Set Custom canApply for Lycanites Equipment
- Shares Most BS_WEAPON, except instability as it checks durability and arc slash as lycanites has custom sweep condition
- Shares Most TOOL, except smelter

As a customTypes, can be toggled off.