### PR TITLE
Fixed lack on consistency with fire extinguishers

### DIFF
--- a/src/main/java/com/shultrea/rin/enchantments/weapon/damage/EnchantmentWaterAspect.java
+++ b/src/main/java/com/shultrea/rin/enchantments/weapon/damage/EnchantmentWaterAspect.java
@@ -4,6 +4,7 @@ import com.shultrea.rin.config.ConfigProvider;
 import com.shultrea.rin.config.EnchantabilityConfig;
 import com.shultrea.rin.config.ModConfig;
 import com.shultrea.rin.enchantments.base.EnchantmentBase;
+import com.shultrea.rin.registry.EnchantmentRegistry;
 import com.shultrea.rin.util.compat.CompatUtil;
 import com.shultrea.rin.util.compat.RLCombatCompat;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -62,7 +63,15 @@ public class EnchantmentWaterAspect extends EnchantmentBase {
 	public boolean isTreasureEnchantment() {
 		return ModConfig.treasure.waterAspect;
 	}
-	
+
+	public static int getLevelValue(EntityLivingBase entity) {
+		if(!EnchantmentRegistry.waterAspect.isEnabled()) return 0;
+		if(entity == null) return 0;
+		ItemStack stack = entity.getHeldItemMainhand();
+		if(CompatUtil.isRLCombatLoaded()) stack = RLCombatCompat.getFireAspectStack(entity);
+		return EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.waterAspect, stack);
+	}
+
 	@SubscribeEvent(priority = EventPriority.HIGH)
 	public void onLivingHurtEvent(LivingHurtEvent event) {
 		if(!this.isEnabled()) return;

--- a/src/main/java/com/shultrea/rin/enchantments/weapon/potiondebuffer/EnchantmentCryogenic.java
+++ b/src/main/java/com/shultrea/rin/enchantments/weapon/potiondebuffer/EnchantmentCryogenic.java
@@ -4,6 +4,7 @@ import com.shultrea.rin.config.ConfigProvider;
 import com.shultrea.rin.config.EnchantabilityConfig;
 import com.shultrea.rin.config.ModConfig;
 import com.shultrea.rin.enchantments.base.EnchantmentBase;
+import com.shultrea.rin.registry.EnchantmentRegistry;
 import com.shultrea.rin.util.compat.CompatUtil;
 import com.shultrea.rin.util.compat.LycanitesMobsCompat;
 import com.shultrea.rin.util.compat.RLCombatCompat;
@@ -70,7 +71,15 @@ public class EnchantmentCryogenic extends EnchantmentBase {
 	public boolean isTreasureEnchantment() {
 		return ModConfig.treasure.cryogenic;
 	}
-	
+
+	public static int getLevelValue(EntityLivingBase entity) {
+		if(!EnchantmentRegistry.cryogenic.isEnabled()) return 0;
+		if(entity == null) return 0;
+		ItemStack stack = entity.getHeldItemMainhand();
+		if(CompatUtil.isRLCombatLoaded()) stack = RLCombatCompat.getFireAspectStack(entity);
+		return EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.cryogenic, stack);
+	}
+
 	@Override
 	public void onEntityDamagedAlt(EntityLivingBase attacker, Entity target, ItemStack weapon, int level) {
 		if(!this.isEnabled()) return;

--- a/src/main/java/com/shultrea/rin/mixin/vanilla/EnchantmentHelperMixin.java
+++ b/src/main/java/com/shultrea/rin/mixin/vanilla/EnchantmentHelperMixin.java
@@ -11,6 +11,8 @@ import com.shultrea.rin.enchantments.weapon.EnchantmentAdvancedKnockback;
 import com.shultrea.rin.enchantments.weapon.EnchantmentAdvancedLooting;
 import com.shultrea.rin.enchantments.weapon.EnchantmentFieryEdge;
 import com.shultrea.rin.enchantments.weapon.EnchantmentTierFA;
+import com.shultrea.rin.enchantments.weapon.damage.EnchantmentWaterAspect;
+import com.shultrea.rin.enchantments.weapon.potiondebuffer.EnchantmentCryogenic;
 import com.shultrea.rin.registry.EnchantmentRegistry;
 import com.shultrea.rin.util.compat.CompatUtil;
 import com.shultrea.rin.util.compat.RLCombatCompat;
@@ -95,7 +97,9 @@ public abstract class EnchantmentHelperMixin {
 			at = @At("RETURN")
 	)
 	private static int soManyEnchantments_vanillaEnchantmentHelper_getFireAspectModifier(int original, EntityLivingBase entity) {
-		boolean hasExtinguish = EnchantmentExtinguish.getLevelValue(entity)>0;
+		boolean hasExtinguish = EnchantmentExtinguish.getLevelValue(entity)>0
+									|| EnchantmentWaterAspect.getLevelValue(entity)>0
+									|| EnchantmentCryogenic.getLevelValue(entity)>0;
 		return hasExtinguish ? 0 : original + EnchantmentTierFA.getLevelValue(entity) + EnchantmentFieryEdge.getLevelValue(entity);
 	}
 	


### PR DESCRIPTION
Applied original Extinguish Curse fix to the rest of the group.

Cryogenic Damage Mult could proc with Ash Destroyer Damage Mult with certain fire timings

Fixing it in favor of players sounded dumb as the incompatibility group is fire setter vs fire extinguishers.
https://discord.com/channels/1129204304037814335/1364557939012145214

Whatever Extinguish was doing was more consistent than the other two


https://github.com/user-attachments/assets/0a287c59-25af-4846-8e20-634f886e6ff8

